### PR TITLE
Repair asset limiting by request tags, add unit test coverage.

### DIFF
--- a/roundwared/db.py
+++ b/roundwared/db.py
@@ -33,7 +33,7 @@ def get_recordings(session_id, tags=None):
 
     logger.debug("Got session_id: %s", session_id)
     session = Session.objects.select_related('project',
-                                           'language').get(id=session_id)
+                                             'language').get(id=session_id)
     project = session.project
 
     tag_list = None
@@ -142,6 +142,7 @@ def filter_recs_for_tags(p, tagids_from_request, l):
     logger.debug(
         "filter_recs_for_tags returned %s Assets" % (len(recs)))
     return recs
+
 
 # Used by audiotrack.py only
 def add_asset_to_session_history(asset_id, session_id, duration):

--- a/roundwared/recording_collection.py
+++ b/roundwared/recording_collection.py
@@ -57,7 +57,7 @@ class RecordingCollection:
         if lock:
             self.lock.acquire()
 
-        tags = getattr(request, "tags", None)
+        tags = request.get("tags", None)
         self.all = db.get_recordings(request["session_id"], tags)
         # Updating nearby_recording will start stream audio asset play back.
         if update_nearby:

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,7 +1,20 @@
 #!/bin/bash
 set -e
 
+# Default to running all tests
+TESTS="tests"
+if [ -n "$1" ]; then
+  TESTS=$1
+  echo Running: $TESTS
+else
+  echo Running All Tests
+fi
+
 # runs Django test_coverage script on rw app and roundware-server tests with appropriate settings
 cd ..
-coverage run --source=roundware,roundwared roundware/manage.py test --settings=roundware.settings.testing tests
-coverage report -m
+coverage run --source=roundware,roundwared roundware/manage.py test --settings=roundware.settings.testing $TESTS
+
+# Only display coverage results on full tests
+if [ "$TESTS" == "tests" ]; then
+  coverage report -m
+fi


### PR DESCRIPTION
I reproduced the discussed issue with tags not filtering assets correctly. Created unit tests to confirm issue, and then fixed. One line change of course.